### PR TITLE
feat(derive): add option to derive `serde(default)` attribute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,11 +50,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "itoa"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
 name = "partially"
 version = "0.1.0"
 dependencies = [
  "partially",
  "partially_derive",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -83,6 +91,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
+name = "serde"
+version = "1.0.189"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.189"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/crates/partially/Cargo.toml
+++ b/crates/partially/Cargo.toml
@@ -21,6 +21,8 @@ derive = ["dep:partially_derive"]
 # Causes `cargo test` to include the derive feature
 # without specifying it on the command line
 partially = { path = ".", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [dependencies]
 partially_derive = { version = "0.1.0", path = "../partially_derive", optional = true }

--- a/crates/partially/tests/derive/mod.rs
+++ b/crates/partially/tests/derive/mod.rs
@@ -1,3 +1,4 @@
 mod basic;
 mod generic;
 mod retyped;
+mod serde;

--- a/crates/partially/tests/derive/serde.rs
+++ b/crates/partially/tests/derive/serde.rs
@@ -1,0 +1,29 @@
+use serde::Deserialize;
+use partially::Partial;
+
+const EMPTY_INPUT: &str = "{}";
+const FILLED_INPUT: &str = "{ \"value\": \"modified\" }";
+
+#[derive(Partial)]
+#[partially(serde, derive(Default, Deserialize))]
+struct Data {
+    value: String,
+}
+
+#[test]
+fn serde_derive() {
+    let empty_partial: PartialData = serde_json::from_str(EMPTY_INPUT).unwrap();
+    let full_partial: PartialData = serde_json::from_str(FILLED_INPUT).unwrap();
+
+    let mut full = Data {
+        value: "initial".to_string(),
+    };
+
+    full.apply_some(empty_partial);
+
+    assert_eq!(full.value, "initial".to_string());
+
+    full.apply_some(full_partial);
+
+    assert_eq!(full.value, "modified".to_string());
+}

--- a/crates/partially_derive/src/internal/derive_receiver.rs
+++ b/crates/partially_derive/src/internal/derive_receiver.rs
@@ -1,4 +1,5 @@
 use darling::{ast, util::PathList, FromDeriveInput};
+use darling::util::Flag;
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 use syn::{Attribute, Generics, Ident, Path, Visibility};
@@ -43,6 +44,9 @@ pub struct DeriveReceiver {
     /// Receives an optional [`Path`] defining the path to the `partially` crate.
     #[darling(rename = "crate")]
     pub krate: Option<Path>,
+
+    /// A flag indicating that the derived struct should contain the `serde(default)` attribute.
+    pub serde: Flag,
 }
 
 impl ToTokens for DeriveReceiver {
@@ -56,6 +60,7 @@ impl ToTokens for DeriveReceiver {
             ref rename,
             ref derive,
             ref krate,
+            ref serde,
         } = *self;
 
         let (_, ty, wher) = generics.split_for_impl();
@@ -82,6 +87,12 @@ impl ToTokens for DeriveReceiver {
                 TokenVec::new_with_vec_and_sep(derive_paths.to_vec(), Separator::Comma);
             tokens.extend(quote! {
                     #[derive(#derive_paths)]
+            });
+        }
+
+        if serde.is_present() {
+            tokens.extend(quote! {
+                #[serde(default)]
             });
         }
 


### PR DESCRIPTION
I really like this crate. It's great for loading multiple layers of configuration but as it wasn't possible to add the `serde(default)` attribute only to the derived struct I've added this flag.