### PR TITLE
feat: Indicate if `apply_some` did apply anything

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ With derive:
 use partially::Partial;
 
 // define a base structure, with the `Partial` derive macro
-#[derive(partially_derive::Partial)]
+#[derive(Partial)]
 // further, instruct the macro to derive `Default` on the generated structure
 #[partially(derive(Default))]
 struct Data {
@@ -40,14 +40,14 @@ fn main() {
         value: "initial".to_string(),
     };
 
-    // apply the empty partial
-    full.apply_some(empty_partial);
+    // apply the empty partial (note that `false` is returned, indicating nothing was applied)
+    assert!(!full.apply_some(empty_partial));
 
     // note that applying the empty partial had no effect
     assert_eq!(full.value, "initial".to_string());
 
-    // apply the full partial
-    full.apply_some(full_partial);
+    // apply the full partial (note that `true` is returned, indicating something was applied)
+    assert!(full.apply_some(full_partial));
 
     // note that applying the full partial modified the value
     assert_eq!(full.value, "modified".to_string());
@@ -68,14 +68,18 @@ struct PartialBase {
     value: Option<String>,
 }
 
-impl partially::Partial for Base {
+impl Partial for Base {
     type Item = PartialBase;
 
     #[allow(clippy::useless_conversion)]
-    fn apply_some(&mut self, partial: Self::Item) {
+    fn apply_some(&mut self, partial: Self::Item) -> bool {
+        let will_apply_some = partial.value.is_some();
+
         if let Some(value) = partial.value {
             self.value = value.into();
         }
+
+        will_apply_some
     }
 }
 
@@ -89,11 +93,11 @@ fn main() {
         value: "initial".to_string(),
     };
 
-    data.apply_some(empty_partial);
+    assert!(!data.apply_some(empty_partial));
 
     assert_eq!(data.value, "initial".to_string());
 
-    data.apply_some(full_partial);
+    assert!(data.apply_some(full_partial));
 
     assert_eq!(data.value, "modified".to_string())
 }

--- a/crates/partially/src/lib.rs
+++ b/crates/partially/src/lib.rs
@@ -73,8 +73,9 @@ pub trait Partial {
     /// The type of the partial structure, that may have [`Some`] values.
     type Item;
 
-    /// Applies [`Some`] values from [`Partial::Item`] to [`self`].
+    /// Applies [`Some`] values from [`Partial::Item`] to [`self`], returning `true` when
+    /// updates were made, and `false` when nothing was applied.
     ///
     /// Note: [`None`] values should not be applied.
-    fn apply_some(&mut self, partial: Self::Item);
+    fn apply_some(&mut self, partial: Self::Item) -> bool;
 }

--- a/crates/partially/tests/apply_some.rs
+++ b/crates/partially/tests/apply_some.rs
@@ -13,10 +13,14 @@ impl partially::Partial for Base {
     type Item = PartialBase;
 
     #[allow(clippy::useless_conversion)]
-    fn apply_some(&mut self, partial: Self::Item) {
+    fn apply_some(&mut self, partial: Self::Item) -> bool {
+        let will_apply_some = partial.value.is_some();
+
         if let Some(value) = partial.value {
             self.value = value.into();
         }
+
+        will_apply_some
     }
 }
 
@@ -31,11 +35,11 @@ fn basic_apply() {
         value: "initial".to_string(),
     };
 
-    data.apply_some(empty_partial);
+    assert!(!data.apply_some(empty_partial));
 
     assert_eq!(data.value, "initial".to_string());
 
-    data.apply_some(full_partial);
+    assert!(data.apply_some(full_partial));
 
-    assert_eq!(data.value, "modified".to_string())
+    assert_eq!(data.value, "modified".to_string());
 }

--- a/crates/partially/tests/derive/basic.rs
+++ b/crates/partially/tests/derive/basic.rs
@@ -17,11 +17,11 @@ fn basic_apply_some() {
         value: "initial".to_string(),
     };
 
-    full.apply_some(empty_partial);
+    assert!(!full.apply_some(empty_partial));
 
     assert_eq!(full.value, "initial".to_string());
 
-    full.apply_some(full_partial);
+    assert!(full.apply_some(full_partial));
 
     assert_eq!(full.value, "modified".to_string());
 }

--- a/crates/partially_derive/src/internal/mod.rs
+++ b/crates/partially_derive/src/internal/mod.rs
@@ -69,7 +69,12 @@ mod test {
             impl partially::Partial for Data {
                 type Item = PartialData;
 
-                fn apply_some(&mut self, partial: Self::Item) {
+                fn apply_some(&mut self, partial: Self::Item) -> bool {
+                    let will_apply_some = partial.str_field.is_some() ||
+                        partial.number_field.is_some() ||
+                        partial.transparent_field.is_some() ||
+                        partial.new_field.is_some();
+
                     if let Some(str_field) = partial.str_field {
                         self.str_field = str_field.into();
                     }
@@ -85,6 +90,8 @@ mod test {
                     if let Some(new_field) = partial.new_field {
                         self.old_field = new_field.into();
                     }
+
+                    will_apply_some
                 }
             }
         };
@@ -133,7 +140,12 @@ mod test {
             impl partially::Partial for Data {
                 type Item = OptData;
 
-                fn apply_some(&mut self, partial: Self::Item) {
+                fn apply_some(&mut self, partial: Self::Item) -> bool {
+                    let will_apply_some = partial.str_field.is_some() ||
+                        partial.number_field.is_some() ||
+                        partial.transparent_field.is_some() ||
+                        partial.new_field.is_some();
+
                     if let Some(str_field) = partial.str_field {
                         self.str_field = str_field.into();
                     }
@@ -149,6 +161,8 @@ mod test {
                     if let Some(new_field) = partial.new_field {
                         self.old_field = new_field.into();
                     }
+
+                    will_apply_some
                 }
             }
         };
@@ -197,7 +211,12 @@ mod test {
             impl<T> partially::Partial for Data<T> {
                 type Item = PartialData<T>;
 
-                fn apply_some(&mut self, partial: Self::Item) {
+                fn apply_some(&mut self, partial: Self::Item) -> bool {
+                    let will_apply_some = partial.type_field.is_some() ||
+                        partial.number_field.is_some() ||
+                        partial.transparent_field.is_some() ||
+                        partial.new_field.is_some();
+
                     if let Some(type_field) = partial.type_field {
                         self.type_field = type_field.into();
                     }
@@ -213,6 +232,8 @@ mod test {
                     if let Some(new_field) = partial.new_field {
                         self.old_field = new_field.into();
                     }
+
+                    will_apply_some
                 }
             }
         };
@@ -262,7 +283,12 @@ mod test {
             impl<T> custom_partially::Partial for Data<T> where T : Sized {
                 type Item = PartialData<T>;
 
-                fn apply_some(&mut self, partial: Self::Item) {
+                fn apply_some(&mut self, partial: Self::Item) -> bool {
+                    let will_apply_some = partial.type_field.is_some() ||
+                        partial.number_field.is_some() ||
+                        partial.transparent_field.is_some() ||
+                        partial.new_field.is_some();
+
                     if let Some(type_field) = partial.type_field {
                         self.type_field = type_field.into();
                     }
@@ -278,6 +304,8 @@ mod test {
                     if let Some(new_field) = partial.new_field {
                         self.old_field = new_field.into();
                     }
+
+                    will_apply_some
                 }
             }
         };
@@ -329,7 +357,12 @@ mod test {
             impl partially::Partial for Data {
                 type Item = PartialData;
 
-                fn apply_some(&mut self, partial: Self::Item) {
+                fn apply_some(&mut self, partial: Self::Item) -> bool {
+                    let will_apply_some = partial.str_field.is_some() ||
+                        partial.number_field.is_some() ||
+                        partial.transparent_field.is_some() ||
+                        partial.new_field.is_some();
+
                     if let Some(str_field) = partial.str_field {
                         self.str_field = str_field.into();
                     }
@@ -345,6 +378,8 @@ mod test {
                     if let Some(new_field) = partial.new_field {
                         self.old_field = new_field.into();
                     }
+
+                    will_apply_some
                 }
             }
         };

--- a/crates/partially_derive/src/internal/token_vec.rs
+++ b/crates/partially_derive/src/internal/token_vec.rs
@@ -13,6 +13,10 @@ pub enum Separator {
     CommaNewline,
     /// Value of `::`.
     ColonColon,
+    /// Value of `&&`
+    And,
+    /// Value of `||`
+    Or,
 }
 
 impl Default for Separator {
@@ -63,6 +67,8 @@ impl<T: ToTokens> ToTokens for TokenVec<T> {
                 Separator::CommaNewline => tokens.extend(quote! {
                     #token,
                 }),
+                Separator::And => tokens.extend(quote!(#token&&)),
+                Separator::Or => tokens.extend(quote!(#token||)),
             }
         }
     }
@@ -147,6 +153,32 @@ mod test {
             b,
             c
         };
+        let expected = expected.into_token_stream().to_string();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn separates_and() {
+        let instance =
+            TokenVec::new_with_vec_and_sep(vec![quote!(a), quote!(b), quote!(c)], Separator::And);
+
+        let actual = instance.into_token_stream().to_string();
+
+        let expected = quote!(a && b && c);
+        let expected = expected.into_token_stream().to_string();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn separates_or() {
+        let instance =
+            TokenVec::new_with_vec_and_sep(vec![quote!(a), quote!(b), quote!(c)], Separator::Or);
+
+        let actual = instance.into_token_stream().to_string();
+
+        let expected = quote!(a || b || c);
         let expected = expected.into_token_stream().to_string();
 
         assert_eq!(actual, expected);


### PR DESCRIPTION
Addresses #8, by returning a boolean from `apply_some` indicating if any values from the partial were assigned to the base. Note the change in return type for `apply_some` in the updated example below:

```rust
// `partially` installed with feature `derive`
use partially::Partial;

// define a base structure, with the `Partial` derive macro
#[derive(Partial)]
// further, instruct the macro to derive `Default` on the generated structure
#[partially(derive(Default))]
struct Data {
    // since no field options are specified, this field will be mapped
    // to an `Option<String>` in the generated structure
    value: String,
}

// example usage
fn main() {
    // since we derived default for the generated struct, we can use that
    // to obtain a partial struct filled with `None`.
    let empty_partial = PartialData::default();

    // we can, of course, also specify values ourself
    let full_partial = PartialData {
        value: Some("modified".to_string()),
    };

    // define a "base" that we'll operate against
    let mut full = Data {
        value: "initial".to_string(),
    };

    // apply the empty partial (note that `false` is returned, indicating nothing was applied)
    assert!(!full.apply_some(empty_partial));

    // note that applying the empty partial had no effect
    assert_eq!(full.value, "initial".to_string());

    // apply the full partial (note that `true` is returned, indicating something was applied)
    assert!(full.apply_some(full_partial));

    // note that applying the full partial modified the value
    assert_eq!(full.value, "modified".to_string());
}
```

Also snuck in a readme fix for #6 
