### PR TITLE
feat(no_std): Support `no_std` targets

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -20,11 +20,11 @@ jobs:
       - name: Install cargo-all-features
         run: cargo install cargo-all-features
       - name: Build
-        run: cargo build-all-features  --exclude test_no_std --workspace --verbose
+        run: cargo build-all-features --exclude test_no_std --workspace --verbose
       - name: Run tests
         run: cargo test-all-features --exclude test_no_std --workspace --verbose
       - name: Run clippy
-        run: cargo clippy --verbose
+        run: cargo clippy --exclude test_no_std --workspace --verbose
 
   build_no_std:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Run clippy
         run: cargo clippy --verbose
 
-  build_test_lint_no_std:
+  build_no_std:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -2,9 +2,9 @@ name: PR validation
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
   workflow_dispatch:
 
 env:
@@ -12,14 +12,15 @@ env:
 
 jobs:
   build_test_lint:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
-    - name: Run clippy
-      run: cargo clippy --verbose
+      - uses: actions/checkout@v3
+      - name: Install cargo-all-features
+        run: cargo install cargo-all-features
+      - name: Build
+        run: cargo build-all-features --verbose
+      - name: Run tests
+        run: cargo test-all-features --verbose
+      - name: Run clippy
+        run: cargo clippy --verbose

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -11,16 +11,27 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build_test_lint:
+  build_test_lint_std:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
       - name: Install cargo-all-features
         run: cargo install cargo-all-features
       - name: Build
-        run: cargo build-all-features --verbose
+        run: cargo build-all-features  --exclude test_no_std --workspace --verbose
       - name: Run tests
-        run: cargo test-all-features --verbose
+        run: cargo test-all-features --exclude test_no_std --workspace --verbose
       - name: Run clippy
         run: cargo clippy --verbose
+
+  build_test_lint_no_std:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      # the test_no_std crate requires the nightly toolchain
+      - uses: dtolnay/rust-toolchain@nightly
+      - name: Build test_no_std
+        run: cd crates/test_no_std && cargo +nightly build --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
+name = "libc"
+version = "0.2.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+
+[[package]]
 name = "partially"
 version = "0.1.1"
 dependencies = [
@@ -145,6 +151,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "test_no_std"
+version = "0.1.0"
+dependencies = [
+ "libc",
+ "partially",
 ]
 
 [[package]]

--- a/crates/partially/Cargo.toml
+++ b/crates/partially/Cargo.toml
@@ -17,6 +17,7 @@ all-features = true
 default = ["std"]
 
 # Enables features that depend on the rust standard library
+# Note: There currently aren't any features that fall into this category
 std = []
 
 # Enables the derive macro

--- a/crates/partially/Cargo.toml
+++ b/crates/partially/Cargo.toml
@@ -14,7 +14,12 @@ categories = ["rust-patterns"]
 all-features = true
 
 [features]
-default = []
+default = ["std"]
+
+# Enables features that depend on the rust standard library
+std = []
+
+# Enables the derive macro
 derive = ["dep:partially_derive"]
 
 [dev-dependencies]

--- a/crates/partially/src/lib.rs
+++ b/crates/partially/src/lib.rs
@@ -1,3 +1,6 @@
+// support `no_std` environments
+#![no_std]
+// include our readme docs
 #![doc = include_str!(concat!("../", env!("CARGO_PKG_README")))]
 
 /// ## partially_derive

--- a/crates/test_no_std/Cargo.toml
+++ b/crates/test_no_std/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "test_no_std"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+libc = { version = "0.2", default-features = false }
+partially = { version = "*", path = "../partially", default-features = false, features = [
+    "derive",
+] }

--- a/crates/test_no_std/README.md
+++ b/crates/test_no_std/README.md
@@ -1,0 +1,12 @@
+# test_no_std
+
+Testbed application for validating partially in a `no_std` environment.
+
+Requires cargo nightly to build:
+
+```
+# Ensure you're in this sub-crate directory, if you're not already
+cd <project_dir>/crates/test_no_std
+# Build with the nightly compiler
+cargo +nightly build
+```

--- a/crates/test_no_std/src/main.rs
+++ b/crates/test_no_std/src/main.rs
@@ -2,11 +2,6 @@
 #![feature(lang_items, start)]
 #![no_std]
 
-#[start]
-fn start(_argc: isize, _argv: *const *const u8) -> isize {
-    0
-}
-
 #[lang = "eh_personality"]
 #[no_mangle]
 pub extern "C" fn rust_eh_personality() {}
@@ -25,4 +20,14 @@ use partially::Partial;
 #[derive(Partial)]
 struct Test {
     data: i32,
+}
+
+#[start]
+fn start(_argc: isize, _argv: *const *const u8) -> isize {
+    let mut base = Test { data: 1 };
+    let partial = PartialTest { data: Some(2) };
+
+    assert!(base.apply_some(partial));
+
+    0
 }

--- a/crates/test_no_std/src/main.rs
+++ b/crates/test_no_std/src/main.rs
@@ -1,0 +1,28 @@
+#![allow(internal_features)]
+#![feature(lang_items, start)]
+#![no_std]
+
+#[start]
+fn start(_argc: isize, _argv: *const *const u8) -> isize {
+    0
+}
+
+#[lang = "eh_personality"]
+#[no_mangle]
+pub extern "C" fn rust_eh_personality() {}
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    unsafe {
+        libc::abort();
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+use partially::Partial;
+
+#[derive(Partial)]
+struct Test {
+    data: i32,
+}


### PR DESCRIPTION
> fixes #7 

This adds support for consuming `partially` in `no_std` environments, and sets up an `std` feature for the future, in the event that we add functionality that is `std`-only compatible. 

It also adds the `test_no_std` crate, which consumes `partially` from a `no_std` application, for testing. Note that this application doesn't build on windows, but is built in linux during CI.