### PR TITLE
feat(derive): implements `Partial` for generated structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "partially"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "partially",
  "partially_derive",
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "partially_derive"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/crates/partially/tests/apply_some.rs
+++ b/crates/partially/tests/apply_some.rs
@@ -24,6 +24,20 @@ impl partially::Partial for Base {
     }
 }
 
+impl partially::Partial for PartialBase {
+    type Item = PartialBase;
+
+    fn apply_some(&mut self, partial: Self::Item) -> bool {
+        let will_apply_some = partial.value.is_some();
+
+        if let Some(value) = partial.value {
+            self.value = value.into();
+        }
+
+        will_apply_some
+    }
+}
+
 #[test]
 fn basic_apply() {
     let empty_partial = PartialBase::default();
@@ -42,4 +56,16 @@ fn basic_apply() {
     assert!(data.apply_some(full_partial));
 
     assert_eq!(data.value, "modified".to_string());
+}
+
+#[test]
+fn partial_apply() {
+    let mut empty_partial = PartialBase::default();
+    let full_partial = PartialBase {
+        value: Some("modified".to_string()),
+    };
+
+    assert!(empty_partial.apply_some(full_partial));
+
+    assert_eq!(empty_partial.value, Some("modified".to_string()));
 }

--- a/crates/partially/tests/derive/basic.rs
+++ b/crates/partially/tests/derive/basic.rs
@@ -3,25 +3,42 @@ use partially::Partial;
 #[derive(Partial)]
 #[partially(derive(Default))]
 struct Data {
-    value: String,
+    a: String,
+    b: String,
 }
 
 #[test]
 fn basic_apply_some() {
     let empty_partial = PartialData::default();
     let full_partial = PartialData {
-        value: Some("modified".to_string()),
+        a: Some("modified".to_string()),
+        b: None,
     };
 
     let mut full = Data {
-        value: "initial".to_string(),
+        a: "initial".to_string(),
+        b: String::default(),
     };
 
     assert!(!full.apply_some(empty_partial));
 
-    assert_eq!(full.value, "initial".to_string());
+    assert_eq!(full.a, "initial".to_string());
 
     assert!(full.apply_some(full_partial));
 
-    assert_eq!(full.value, "modified".to_string());
+    assert_eq!(full.a, "modified".to_string());
+}
+
+#[test]
+fn partial_apply_some() {
+    let mut empty_partial = PartialData::default();
+    let full_partial = PartialData {
+        a: Some("modified".to_string()),
+        b: None,
+    };
+
+    assert!(empty_partial.apply_some(full_partial));
+
+    assert_eq!(empty_partial.a, Some("modified".to_string()));
+    assert_eq!(empty_partial.b, None);
 }

--- a/crates/partially_derive/src/internal/derive_receiver.rs
+++ b/crates/partially_derive/src/internal/derive_receiver.rs
@@ -153,6 +153,20 @@ impl ToTokens for DeriveReceiver {
         // write the impl
         tokens.extend(quote! {
             #impl_partial
+        });
+
+        // create the partial => partial impl
+        let partial_impl_partial = ImplPartial {
+            krate,
+            from_ident: &to_ident,
+            to_ident: &to_ident,
+            generics,
+            fields: &fields,
+        };
+
+        // write it
+        tokens.extend(quote! {
+            #partial_impl_partial
         })
     }
 }

--- a/crates/partially_derive/src/internal/mod.rs
+++ b/crates/partially_derive/src/internal/mod.rs
@@ -94,6 +94,35 @@ mod test {
                     will_apply_some
                 }
             }
+
+            impl partially::Partial for PartialData {
+                type Item = PartialData;
+
+                fn apply_some(&mut self, partial: Self::Item) -> bool {
+                    let will_apply_some = partial.str_field.is_some() ||
+                        partial.number_field.is_some() ||
+                        partial.transparent_field.is_some() ||
+                        partial.new_field.is_some();
+
+                    if let Some(str_field) = partial.str_field {
+                        self.str_field = str_field.into();
+                    }
+
+                    if let Some(number_field) = partial.number_field {
+                        self.number_field = number_field.into();
+                    }
+
+                    if let Some(transparent_field) = partial.transparent_field {
+                        self.transparent_field = transparent_field.into();
+                    }
+
+                    if let Some(new_field) = partial.new_field {
+                        self.old_field = new_field.into();
+                    }
+
+                    will_apply_some
+                }
+            }
         };
 
         assert_eq!(expanded.to_string(), expected.to_string());
@@ -165,6 +194,35 @@ mod test {
                     will_apply_some
                 }
             }
+
+            impl partially::Partial for OptData {
+                type Item = OptData;
+
+                fn apply_some(&mut self, partial: Self::Item) -> bool {
+                    let will_apply_some = partial.str_field.is_some() ||
+                        partial.number_field.is_some() ||
+                        partial.transparent_field.is_some() ||
+                        partial.new_field.is_some();
+
+                    if let Some(str_field) = partial.str_field {
+                        self.str_field = str_field.into();
+                    }
+
+                    if let Some(number_field) = partial.number_field {
+                        self.number_field = number_field.into();
+                    }
+
+                    if let Some(transparent_field) = partial.transparent_field {
+                        self.transparent_field = transparent_field.into();
+                    }
+
+                    if let Some(new_field) = partial.new_field {
+                        self.old_field = new_field.into();
+                    }
+
+                    will_apply_some
+                }
+            }
         };
 
         assert_eq!(expanded.to_string(), expected.to_string());
@@ -209,6 +267,35 @@ mod test {
             }
 
             impl<T> partially::Partial for Data<T> {
+                type Item = PartialData<T>;
+
+                fn apply_some(&mut self, partial: Self::Item) -> bool {
+                    let will_apply_some = partial.type_field.is_some() ||
+                        partial.number_field.is_some() ||
+                        partial.transparent_field.is_some() ||
+                        partial.new_field.is_some();
+
+                    if let Some(type_field) = partial.type_field {
+                        self.type_field = type_field.into();
+                    }
+
+                    if let Some(number_field) = partial.number_field {
+                        self.number_field = number_field.into();
+                    }
+
+                    if let Some(transparent_field) = partial.transparent_field {
+                        self.transparent_field = transparent_field.into();
+                    }
+
+                    if let Some(new_field) = partial.new_field {
+                        self.old_field = new_field.into();
+                    }
+
+                    will_apply_some
+                }
+            }
+
+            impl<T> partially::Partial for PartialData<T> {
                 type Item = PartialData<T>;
 
                 fn apply_some(&mut self, partial: Self::Item) -> bool {
@@ -308,6 +395,35 @@ mod test {
                     will_apply_some
                 }
             }
+
+            impl<T> custom_partially::Partial for PartialData<T> where T : Sized {
+                type Item = PartialData<T>;
+
+                fn apply_some(&mut self, partial: Self::Item) -> bool {
+                    let will_apply_some = partial.type_field.is_some() ||
+                        partial.number_field.is_some() ||
+                        partial.transparent_field.is_some() ||
+                        partial.new_field.is_some();
+
+                    if let Some(type_field) = partial.type_field {
+                        self.type_field = type_field.into();
+                    }
+
+                    if let Some(number_field) = partial.number_field {
+                        self.number_field = number_field.into();
+                    }
+
+                    if let Some(transparent_field) = partial.transparent_field {
+                        self.transparent_field = transparent_field.into();
+                    }
+
+                    if let Some(new_field) = partial.new_field {
+                        self.old_field = new_field.into();
+                    }
+
+                    will_apply_some
+                }
+            }
         };
 
         assert_eq!(expanded.to_string(), expected.to_string());
@@ -355,6 +471,35 @@ mod test {
             }
 
             impl partially::Partial for Data {
+                type Item = PartialData;
+
+                fn apply_some(&mut self, partial: Self::Item) -> bool {
+                    let will_apply_some = partial.str_field.is_some() ||
+                        partial.number_field.is_some() ||
+                        partial.transparent_field.is_some() ||
+                        partial.new_field.is_some();
+
+                    if let Some(str_field) = partial.str_field {
+                        self.str_field = str_field.into();
+                    }
+
+                    if let Some(number_field) = partial.number_field {
+                        self.number_field = number_field.into();
+                    }
+
+                    if let Some(transparent_field) = partial.transparent_field {
+                        self.transparent_field = transparent_field.into();
+                    }
+
+                    if let Some(new_field) = partial.new_field {
+                        self.old_field = new_field.into();
+                    }
+
+                    will_apply_some
+                }
+            }
+
+            impl partially::Partial for PartialData {
                 type Item = PartialData;
 
                 fn apply_some(&mut self, partial: Self::Item) -> bool {

--- a/crates/test_no_std/src/main.rs
+++ b/crates/test_no_std/src/main.rs
@@ -29,5 +29,10 @@ fn start(_argc: isize, _argv: *const *const u8) -> isize {
 
     assert!(base.apply_some(partial));
 
+    let mut base = PartialTest { data: None };
+    let partial = PartialTest { data: Some(2) };
+
+    assert!(base.apply_some(partial));
+
     0
 }


### PR DESCRIPTION
This allows `GeneratedStruct.apply_some(GeneratedStruct)` to work, for any GeneratedStruct that was created by the `partially_derive::Partial` macro.



closes #14