### PR TITLE
feat(derive): Add `nested` opt

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,3 +169,9 @@ Instructs the macro to skip wrapping the generated field in `Option<T>`, instead
 Instructs the macro to use the provided type instead of `Option<T>` when generating the field. Note that the provided type will be used verbatim, so if you expect an `Option<T>` value, you'll need to manually specify that.
 
 Note: When using `as_type`, the given type must `Into<BaseType>` where `BaseType` is the original field type. This is required for `Partial` trait implementation.
+
+#### nested
+
+> Usage example: `#[partially(nested)]`
+
+Indicates to the macro that this field is `Partial`. The type in the generated struct will then be the associated `Partial::Item` type of the field's type and the struct's `Partial::apply_some` implementation will call `Partial::apply_some` on the field.

--- a/crates/partially/src/lib.rs
+++ b/crates/partially/src/lib.rs
@@ -39,6 +39,9 @@
 /// > Usage example: `#[partially(as_type = "Option<f32>")]`.
 /// Instructs the macro to use the provided type instead of [`Option<T>`] when generating the field. Note that the provided type will be used verbatim, so if you expect an [`Option<T>`] value, you'll need to manually specify that.
 /// Note: When using `as_type`, the given type must `Into<BaseType>` where `BaseType` is the original field type. This is required for `Partial` trait implementation.
+/// ### nested
+/// > Usage example: `#[partially(nested)]`
+/// Indicates to the macro that this field is [`Partial`]. The type in the generated struct will then be the associated [`Partial::Item`] type of the field's type and the struct's [`Partial::apply_some`] implementation will call [`Partial::apply_some`] on the field.
 ///
 /// ## Example
 /// ```

--- a/crates/partially/tests/derive/mod.rs
+++ b/crates/partially/tests/derive/mod.rs
@@ -1,4 +1,5 @@
 mod basic;
 mod container_attrs;
 mod generic;
+mod nested;
 mod retyped;

--- a/crates/partially/tests/derive/nested.rs
+++ b/crates/partially/tests/derive/nested.rs
@@ -1,0 +1,42 @@
+use partially::Partial;
+
+#[derive(Debug, partially_derive::Partial)]
+#[partially(derive(Default))]
+struct Data2 {
+    v: String,
+}
+
+#[derive(Debug, partially_derive::Partial)]
+#[partially(derive(Default))]
+struct Data1 {
+    v: String,
+    #[partially(nested)]
+    d2: Data2,
+}
+
+
+#[test]
+fn nested_apply_some() {
+    let mut data = Data1 {
+        v: "v1".to_string(),
+        d2: Data2 {
+            v: "v2".to_string(),
+        },
+    };
+
+    let empty_partial = PartialData1::default();
+    let full_partial = PartialData1 {
+        v: Some("v3".to_string()),
+        d2: PartialData2 {
+            v: Some("v4".to_string()),
+        },
+    };
+
+    data.apply_some(empty_partial);
+    assert_eq!(data.v, "v1");
+    assert_eq!(data.d2.v, "v2");
+
+    data.apply_some(full_partial);
+    assert_eq!(data.v, "v3");
+    assert_eq!(data.d2.v, "v4");
+}

--- a/crates/partially_derive/src/internal/mod.rs
+++ b/crates/partially_derive/src/internal/mod.rs
@@ -63,14 +63,15 @@ mod test {
                 #[some_attr]
                 number_field: Option<f32>,
                 transparent_field: Option<String>,
-                new_field: Option<String>
+                new_field: Option<String>,
             }
 
             impl partially::Partial for Data {
                 type Item = PartialData;
 
                 fn apply_some(&mut self, partial: Self::Item) -> bool {
-                    let will_apply_some = partial.str_field.is_some() ||
+                    let mut will_apply_some = false ||
+                        partial.str_field.is_some() ||
                         partial.number_field.is_some() ||
                         partial.transparent_field.is_some() ||
                         partial.new_field.is_some();
@@ -99,7 +100,8 @@ mod test {
                 type Item = PartialData;
 
                 fn apply_some(&mut self, partial: Self::Item) -> bool {
-                    let will_apply_some = partial.str_field.is_some() ||
+                    let mut will_apply_some = false ||
+                        partial.str_field.is_some() ||
                         partial.number_field.is_some() ||
                         partial.transparent_field.is_some() ||
                         partial.new_field.is_some();
@@ -163,14 +165,15 @@ mod test {
                 #[some_attr]
                 number_field: Option<f32>,
                 transparent_field: Option<String>,
-                new_field: Option<String>
+                new_field: Option<String>,
             }
 
             impl partially::Partial for Data {
                 type Item = OptData;
 
                 fn apply_some(&mut self, partial: Self::Item) -> bool {
-                    let will_apply_some = partial.str_field.is_some() ||
+                    let mut will_apply_some = false ||
+                        partial.str_field.is_some() ||
                         partial.number_field.is_some() ||
                         partial.transparent_field.is_some() ||
                         partial.new_field.is_some();
@@ -199,7 +202,8 @@ mod test {
                 type Item = OptData;
 
                 fn apply_some(&mut self, partial: Self::Item) -> bool {
-                    let will_apply_some = partial.str_field.is_some() ||
+                    let mut will_apply_some = false ||
+                        partial.str_field.is_some() ||
                         partial.number_field.is_some() ||
                         partial.transparent_field.is_some() ||
                         partial.new_field.is_some();
@@ -263,14 +267,15 @@ mod test {
                 #[some_attr]
                 number_field: Option<f32>,
                 transparent_field: Option<String>,
-                new_field: Option<String>
+                new_field: Option<String>,
             }
 
             impl<T> partially::Partial for Data<T> {
                 type Item = PartialData<T>;
 
                 fn apply_some(&mut self, partial: Self::Item) -> bool {
-                    let will_apply_some = partial.type_field.is_some() ||
+                    let mut will_apply_some = false ||
+                        partial.type_field.is_some() ||
                         partial.number_field.is_some() ||
                         partial.transparent_field.is_some() ||
                         partial.new_field.is_some();
@@ -299,7 +304,8 @@ mod test {
                 type Item = PartialData<T>;
 
                 fn apply_some(&mut self, partial: Self::Item) -> bool {
-                    let will_apply_some = partial.type_field.is_some() ||
+                    let mut will_apply_some = false ||
+                        partial.type_field.is_some() ||
                         partial.number_field.is_some() ||
                         partial.transparent_field.is_some() ||
                         partial.new_field.is_some();
@@ -364,14 +370,15 @@ mod test {
                 #[some_attr]
                 number_field: Option<f32>,
                 transparent_field: Option<String>,
-                new_field: Option<String>
+                new_field: Option<String>,
             }
 
             impl<T> custom_partially::Partial for Data<T> where T : Sized {
                 type Item = PartialData<T>;
 
                 fn apply_some(&mut self, partial: Self::Item) -> bool {
-                    let will_apply_some = partial.type_field.is_some() ||
+                    let mut will_apply_some = false ||
+                        partial.type_field.is_some() ||
                         partial.number_field.is_some() ||
                         partial.transparent_field.is_some() ||
                         partial.new_field.is_some();
@@ -400,7 +407,8 @@ mod test {
                 type Item = PartialData<T>;
 
                 fn apply_some(&mut self, partial: Self::Item) -> bool {
-                    let will_apply_some = partial.type_field.is_some() ||
+                    let mut will_apply_some = false ||
+                        partial.type_field.is_some() ||
                         partial.number_field.is_some() ||
                         partial.transparent_field.is_some() ||
                         partial.new_field.is_some();
@@ -467,14 +475,15 @@ mod test {
                 #[some_attr]
                 number_field: Option<f32>,
                 transparent_field: Option<String>,
-                new_field: Option<String>
+                new_field: Option<String>,
             }
 
             impl partially::Partial for Data {
                 type Item = PartialData;
 
                 fn apply_some(&mut self, partial: Self::Item) -> bool {
-                    let will_apply_some = partial.str_field.is_some() ||
+                    let mut will_apply_some = false ||
+                        partial.str_field.is_some() ||
                         partial.number_field.is_some() ||
                         partial.transparent_field.is_some() ||
                         partial.new_field.is_some();
@@ -503,7 +512,8 @@ mod test {
                 type Item = PartialData;
 
                 fn apply_some(&mut self, partial: Self::Item) -> bool {
-                    let will_apply_some = partial.str_field.is_some() ||
+                    let mut will_apply_some = false ||
+                        partial.str_field.is_some() ||
                         partial.number_field.is_some() ||
                         partial.transparent_field.is_some() ||
                         partial.new_field.is_some();


### PR DESCRIPTION
Hi Ben,

thank you for this crate! In my project I have some `Partial` structs with fields that are `Partial` as well. Therefore, I implemented a way to use the `Partial::Item` type in the generated struct and call `apply_some` on the field in the implementation via a new `nested` attribute.