### PR TITLE
feat(derive): add explicit nested field option

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ Instructs the macro to omit the field from the generated struct. By default, no 
 
 Instructs the macro to skip wrapping the generated field in `Option<T>`, instead transparently mirroring the field type into the generated struct.
 
+Note: this can also be used to opt out of automatic nested partial generation for a field.
+
 #### as_type
 
 > Usage example: `#[partially(as_type = "Option<f32>")]`.
@@ -169,3 +171,9 @@ Instructs the macro to skip wrapping the generated field in `Option<T>`, instead
 Instructs the macro to use the provided type instead of `Option<T>` when generating the field. Note that the provided type will be used verbatim, so if you expect an `Option<T>` value, you'll need to manually specify that.
 
 Note: When using `as_type`, the given type must `Into<BaseType>` where `BaseType` is the original field type. This is required for `Partial` trait implementation.
+
+### Automatic nested partials
+
+If a field looks like another user-defined struct type (for example `Address`), the generated partial field will transparently use `PartialAddress` and `apply_some` will recursively apply that nested partial.
+
+This means nested partial support works without any extra field attribute on the parent type.

--- a/README.md
+++ b/README.md
@@ -162,8 +162,6 @@ Instructs the macro to omit the field from the generated struct. By default, no 
 
 Instructs the macro to skip wrapping the generated field in `Option<T>`, instead transparently mirroring the field type into the generated struct.
 
-Note: this can also be used to opt out of automatic nested partial generation for a field.
-
 #### as_type
 
 > Usage example: `#[partially(as_type = "Option<f32>")]`.
@@ -172,8 +170,8 @@ Instructs the macro to use the provided type instead of `Option<T>` when generat
 
 Note: When using `as_type`, the given type must `Into<BaseType>` where `BaseType` is the original field type. This is required for `Partial` trait implementation.
 
-### Automatic nested partials
+#### nested
 
-If a field looks like another user-defined struct type (for example `Address`), the generated partial field will transparently use `PartialAddress` and `apply_some` will recursively apply that nested partial.
+> Usage example: `#[partially(nested)]`.
 
-This means nested partial support works without any extra field attribute on the parent type.
+Instructs the macro to treat this field's type as `Partial` itself. The generated field type becomes `<FieldType as Partial>::Item`, and generated `apply_some` recursively applies updates via `Partial::apply_some`.

--- a/crates/partially/src/lib.rs
+++ b/crates/partially/src/lib.rs
@@ -39,6 +39,10 @@
 /// > Usage example: `#[partially(as_type = "Option<f32>")]`.
 /// Instructs the macro to use the provided type instead of [`Option<T>`] when generating the field. Note that the provided type will be used verbatim, so if you expect an [`Option<T>`] value, you'll need to manually specify that.
 /// Note: When using `as_type`, the given type must `Into<BaseType>` where `BaseType` is the original field type. This is required for `Partial` trait implementation.
+/// ### nested partials (automatic)
+/// For fields that look like user-defined types (for example, `Address`), the derive macro
+/// will automatically use the generated partial type (for example, `PartialAddress`) and call
+/// [`Partial::apply_some`] on that field, enabling nested updates without any extra field attribute.
 ///
 /// ## Example
 /// ```

--- a/crates/partially/src/lib.rs
+++ b/crates/partially/src/lib.rs
@@ -39,10 +39,11 @@
 /// > Usage example: `#[partially(as_type = "Option<f32>")]`.
 /// Instructs the macro to use the provided type instead of [`Option<T>`] when generating the field. Note that the provided type will be used verbatim, so if you expect an [`Option<T>`] value, you'll need to manually specify that.
 /// Note: When using `as_type`, the given type must `Into<BaseType>` where `BaseType` is the original field type. This is required for `Partial` trait implementation.
-/// ### nested partials (automatic)
-/// For fields that look like user-defined types (for example, `Address`), the derive macro
-/// will automatically use the generated partial type (for example, `PartialAddress`) and call
-/// [`Partial::apply_some`] on that field, enabling nested updates without any extra field attribute.
+/// ### nested
+/// > Usage example: `#[partially(nested)]`.
+/// Instructs the macro to treat this field as [`Partial`]. The generated field type becomes
+/// `<FieldType as Partial>::Item`, and generated [`Partial::apply_some`] recursively applies
+/// the nested value via [`Partial::apply_some`].
 ///
 /// ## Example
 /// ```

--- a/crates/partially/tests/derive/mod.rs
+++ b/crates/partially/tests/derive/mod.rs
@@ -1,4 +1,5 @@
 mod basic;
 mod container_attrs;
 mod generic;
+mod nested;
 mod retyped;

--- a/crates/partially/tests/derive/nested.rs
+++ b/crates/partially/tests/derive/nested.rs
@@ -41,6 +41,30 @@ fn nested_apply_some() {
 
 #[derive(partially_derive::Partial)]
 #[partially(derive(Default))]
+struct OuterNoNested {
+    inner: Inner,
+}
+
+#[test]
+fn non_nested_field_remains_option_wrapped() {
+    let mut value = OuterNoNested {
+        inner: Inner {
+            value: "before".to_string(),
+        },
+    };
+
+    let patch = PartialOuterNoNested {
+        inner: Some(Inner {
+            value: "after".to_string(),
+        }),
+    };
+
+    assert!(value.apply_some(patch));
+    assert_eq!(value.inner.value, "after".to_string());
+}
+
+#[derive(partially_derive::Partial)]
+#[partially(derive(Default))]
 struct GenericOuter<T> {
     value: T,
 }

--- a/crates/partially/tests/derive/nested.rs
+++ b/crates/partially/tests/derive/nested.rs
@@ -10,6 +10,7 @@ struct Inner {
 #[partially(derive(Default))]
 struct Outer {
     top: String,
+    #[partially(nested)]
     inner: Inner,
 }
 
@@ -47,6 +48,7 @@ struct GenericOuter<T> {
 #[derive(partially_derive::Partial)]
 #[partially(derive(Default))]
 struct Wrapper {
+    #[partially(nested)]
     generic: GenericOuter<String>,
 }
 

--- a/crates/partially/tests/derive/nested.rs
+++ b/crates/partially/tests/derive/nested.rs
@@ -71,7 +71,7 @@ fn generic_nested_apply_some() {
 #[derive(partially_derive::Partial)]
 #[partially(derive(Default))]
 struct ExplicitOverridesStillWin {
-    #[partially(as_type = "Option<String>")]
+    #[partially(as_type = "Option<Inner>")]
     inner: Inner,
 }
 
@@ -84,7 +84,9 @@ fn explicit_as_type_still_applies() {
     };
 
     let patch = PartialExplicitOverridesStillWin {
-        inner: Some("after".to_string()),
+        inner: Some(Inner {
+            value: "after".to_string(),
+        }),
     };
 
     assert!(value.apply_some(patch));

--- a/crates/partially/tests/derive/nested.rs
+++ b/crates/partially/tests/derive/nested.rs
@@ -1,0 +1,92 @@
+use partially::Partial;
+
+#[derive(partially_derive::Partial)]
+#[partially(derive(Default))]
+struct Inner {
+    value: String,
+}
+
+#[derive(partially_derive::Partial)]
+#[partially(derive(Default))]
+struct Outer {
+    top: String,
+    inner: Inner,
+}
+
+#[test]
+fn nested_apply_some() {
+    let mut outer = Outer {
+        top: "top-initial".to_string(),
+        inner: Inner {
+            value: "inner-initial".to_string(),
+        },
+    };
+
+    assert!(!outer.apply_some(PartialOuter::default()));
+    assert_eq!(outer.top, "top-initial".to_string());
+    assert_eq!(outer.inner.value, "inner-initial".to_string());
+
+    let nested_only = PartialOuter {
+        top: None,
+        inner: PartialInner {
+            value: Some("inner-updated".to_string()),
+        },
+    };
+
+    assert!(outer.apply_some(nested_only));
+    assert_eq!(outer.top, "top-initial".to_string());
+    assert_eq!(outer.inner.value, "inner-updated".to_string());
+}
+
+#[derive(partially_derive::Partial)]
+#[partially(derive(Default))]
+struct GenericOuter<T> {
+    value: T,
+}
+
+#[derive(partially_derive::Partial)]
+#[partially(derive(Default))]
+struct Wrapper {
+    generic: GenericOuter<String>,
+}
+
+#[test]
+fn generic_nested_apply_some() {
+    let mut wrapper = Wrapper {
+        generic: GenericOuter {
+            value: "before".to_string(),
+        },
+    };
+
+    let patch = PartialWrapper {
+        generic: PartialGenericOuter {
+            value: Some("after".to_string()),
+        },
+    };
+
+    assert!(wrapper.apply_some(patch));
+    assert_eq!(wrapper.generic.value, "after".to_string());
+}
+
+#[derive(partially_derive::Partial)]
+#[partially(derive(Default))]
+struct ExplicitOverridesStillWin {
+    #[partially(as_type = "Option<String>")]
+    inner: Inner,
+}
+
+#[test]
+fn explicit_as_type_still_applies() {
+    let mut value = ExplicitOverridesStillWin {
+        inner: Inner {
+            value: "before".to_string(),
+        },
+    };
+
+    let patch = PartialExplicitOverridesStillWin {
+        inner: Some("after".to_string()),
+    };
+
+    assert!(value.apply_some(patch));
+    assert_eq!(value.inner.value, "after".to_string());
+}

--- a/crates/partially_derive/CHANGELOG.md
+++ b/crates/partially_derive/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- *(derive)* transparently treat nested `Partial` fields as nested partials without an extra field attribute
+- *(derive)* add `#[partially(nested)]` field option to map to `<FieldType as Partial>::Item` and recurse with `apply_some`
 
 ## [0.2.1](https://github.com/bengreenier/partially/compare/partially_derive-v0.2.0...partially_derive-v0.2.1) - 2024-01-20
 

--- a/crates/partially_derive/CHANGELOG.md
+++ b/crates/partially_derive/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- *(derive)* transparently treat nested `Partial` fields as nested partials without an extra field attribute
+
 ## [0.2.1](https://github.com/bengreenier/partially/compare/partially_derive-v0.2.0...partially_derive-v0.2.1) - 2024-01-20
 
 ### Added

--- a/crates/partially_derive/src/internal/derive_receiver.rs
+++ b/crates/partially_derive/src/internal/derive_receiver.rs
@@ -5,7 +5,7 @@ use darling::{
 };
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
-use syn::{Attribute, Generics, Ident, Path, Visibility};
+use syn::{parse_quote, Attribute, Generics, Ident, Path, Visibility};
 
 use super::{
     field_receiver::FieldReceiver,
@@ -89,6 +89,13 @@ impl ToTokens for DeriveReceiver {
             ref krate,
         } = *self;
 
+        // parse the crate config, or use `partially` for the crate path
+        let krate = if let Some(krate) = krate {
+            krate.to_owned()
+        } else {
+            parse_quote!(partially)
+        };
+
         let (_, ty, wher) = generics.split_for_impl();
 
         let fields: Vec<_> = data
@@ -132,7 +139,13 @@ impl ToTokens for DeriveReceiver {
             #additional_attrs
         });
 
-        let field_tokens = TokenVec::new_with_vec_and_sep(fields.clone(), Separator::CommaNewline);
+        let mut field_tokens: Vec<TokenStream> = Vec::new();
+        for field in &fields {
+            let mut token = TokenStream::new();
+            field.to_tokens_with_krate(&mut token, &krate);
+            field_tokens.push(token);
+        }
+        let field_tokens = TokenVec::new_with_vec_and_sep(field_tokens, Separator::CommaNewline);
 
         // write the struct
         tokens.extend(quote! {
@@ -143,7 +156,7 @@ impl ToTokens for DeriveReceiver {
 
         // create the impl
         let impl_partial = ImplPartial {
-            krate,
+            krate: &krate,
             from_ident: ident,
             to_ident: &to_ident,
             generics,
@@ -157,7 +170,7 @@ impl ToTokens for DeriveReceiver {
 
         // create the partial => partial impl
         let partial_impl_partial = ImplPartial {
-            krate,
+            krate: &krate,
             from_ident: &to_ident,
             to_ident: &to_ident,
             generics,

--- a/crates/partially_derive/src/internal/field_receiver.rs
+++ b/crates/partially_derive/src/internal/field_receiver.rs
@@ -1,6 +1,7 @@
 use darling::{util::Flag, FromField, Result};
+use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
-use syn::{parse_quote, Ident, PathArguments, Type, Visibility};
+use syn::{parse_quote, Ident, Path, Type, Visibility};
 
 #[derive(Debug, FromField)]
 #[darling(attributes(partially), forward_attrs, and_then = FieldReceiver::validate)]
@@ -39,97 +40,14 @@ pub struct FieldReceiver {
     /// Note: If specified, the given [`Type`] will be used verbatim, not wrapped in an [`Option`].
     /// Note: By default, [`Option<Self::ty>`] is used.
     pub as_type: Option<Type>,
+
+    /// A flag indicating the field's type is itself [`partially::Partial`].
+    ///
+    /// Note: When present, the generated field type is `<Self::ty as Partial>::Item`.
+    pub nested: Flag,
 }
 
 impl FieldReceiver {
-    fn auto_nested_ty(&self) -> Option<Type> {
-        if self.omit.is_present() || self.transparent.is_present() || self.as_type.is_some() {
-            return None;
-        }
-
-        let Type::Path(mut path) = self.ty.clone() else {
-            return None;
-        };
-
-        if path.qself.is_some() {
-            return None;
-        }
-
-        let first_ident = path.path.segments.first().map(|s| s.ident.to_string())?;
-        if matches!(first_ident.as_str(), "std" | "core" | "alloc") {
-            return None;
-        }
-
-        let last = path.path.segments.last_mut()?;
-        match last.arguments {
-            PathArguments::None | PathArguments::AngleBracketed(_) => {}
-            _ => return None,
-        }
-
-        let type_name = last.ident.to_string();
-        if !type_name
-            .chars()
-            .next()
-            .map(|ch| ch.is_ascii_uppercase())
-            .unwrap_or(false)
-        {
-            return None;
-        }
-
-        if type_name.starts_with("Partial")
-            || matches!(
-                type_name.as_str(),
-                "String"
-                    | "Self"
-                    | "bool"
-                    | "char"
-                    | "str"
-                    | "i8"
-                    | "i16"
-                    | "i32"
-                    | "i64"
-                    | "i128"
-                    | "isize"
-                    | "u8"
-                    | "u16"
-                    | "u32"
-                    | "u64"
-                    | "u128"
-                    | "usize"
-                    | "f32"
-                    | "f64"
-                    | "Option"
-                    | "Vec"
-                    | "Box"
-                    | "Rc"
-                    | "Arc"
-                    | "Cow"
-                    | "Result"
-                    | "HashMap"
-                    | "BTreeMap"
-                    | "HashSet"
-                    | "BTreeSet"
-            )
-            || (type_name.len() == 1
-                && type_name
-                    .chars()
-                    .next()
-                    .map(|ch| ch.is_ascii_uppercase())
-                    .unwrap_or(false))
-        {
-            return None;
-        }
-
-        let partial_name = format!("Partial{type_name}");
-        last.ident = Ident::new(&partial_name, last.ident.span());
-
-        Some(Type::Path(path))
-    }
-
-    pub fn is_auto_nested(&self) -> bool {
-        self.auto_nested_ty().is_some()
-    }
-
     fn validate(self) -> Result<Self> {
         let mut acc = darling::Error::accumulator();
 
@@ -140,25 +58,30 @@ impl FieldReceiver {
         }
 
         if self.omit.is_present()
-            && (self.rename.is_some() || self.transparent.is_present() || self.as_type.is_some())
+            && (self.rename.is_some()
+                || self.transparent.is_present()
+                || self.as_type.is_some()
+                || self.nested.is_present())
         {
             acc.push(darling::Error::custom(
                 "cannot use omit with any other options",
             ));
         }
 
-        if self.transparent.is_present() && self.as_type.is_some() {
+        if self.transparent.is_present() as i32
+            + self.as_type.is_some() as i32
+            + self.nested.is_present() as i32
+            > 1
+        {
             acc.push(darling::Error::custom(
-                "cannot use both transparent and as_type",
+                "transparent, as_type, and nested are mutually exclusive",
             ));
         }
 
         acc.finish_with(self)
     }
-}
 
-impl ToTokens for FieldReceiver {
-    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+    pub fn to_tokens_with_krate(&self, tokens: &mut TokenStream, krate: &Path) {
         if self.omit.is_present() {
             return;
         }
@@ -177,8 +100,8 @@ impl ToTokens for FieldReceiver {
             src_type.to_owned()
         } else if let Some(ty) = &self.as_type {
             ty.to_owned()
-        } else if let Some(nested) = self.auto_nested_ty() {
-            nested
+        } else if self.nested.is_present() {
+            parse_quote!(<#src_type as #krate::Partial>::Item)
         } else {
             let ty: Type = parse_quote! {
                 Option<#src_type>
@@ -202,6 +125,13 @@ impl ToTokens for FieldReceiver {
     }
 }
 
+impl ToTokens for FieldReceiver {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let krate: Path = parse_quote!(partially);
+        self.to_tokens_with_krate(tokens, &krate);
+    }
+}
+
 #[cfg(test)]
 mod test {
     use darling::util::Flag;
@@ -221,6 +151,7 @@ mod test {
             omit: Flag::default(),
             transparent: Flag::default(),
             as_type: None,
+            nested: Flag::default(),
         }
     }
 
@@ -259,6 +190,33 @@ mod test {
         instance.as_type = Some(syn::Type::Verbatim(quote!(NewDummyField)));
 
         assert!(instance.validate().is_err())
+    }
+
+    #[test]
+    fn invalidate_omit_nested() {
+        let mut instance = make_dummy();
+        instance.omit = Flag::present();
+        instance.nested = Flag::present();
+
+        assert!(instance.validate().is_err())
+    }
+
+    #[test]
+    fn invalidate_transparent_as_type_nested() {
+        let mut instance = make_dummy();
+        instance.transparent = Flag::present();
+        instance.as_type = Some(syn::Type::Verbatim(quote!(NewDummyField)));
+        assert!(instance.validate().is_err());
+
+        let mut instance = make_dummy();
+        instance.transparent = Flag::present();
+        instance.nested = Flag::present();
+        assert!(instance.validate().is_err());
+
+        let mut instance = make_dummy();
+        instance.as_type = Some(syn::Type::Verbatim(quote!(NewDummyField)));
+        instance.nested = Flag::present();
+        assert!(instance.validate().is_err());
     }
 
     #[test]

--- a/crates/partially_derive/src/internal/field_receiver.rs
+++ b/crates/partially_derive/src/internal/field_receiver.rs
@@ -1,6 +1,6 @@
 use darling::{util::Flag, FromField, Result};
 use quote::{quote, ToTokens};
-use syn::{parse_quote, Ident, Type, Visibility};
+use syn::{parse_quote, Ident, PathArguments, Type, Visibility};
 
 #[derive(Debug, FromField)]
 #[darling(attributes(partially), forward_attrs, and_then = FieldReceiver::validate)]
@@ -42,6 +42,94 @@ pub struct FieldReceiver {
 }
 
 impl FieldReceiver {
+    fn auto_nested_ty(&self) -> Option<Type> {
+        if self.omit.is_present() || self.transparent.is_present() || self.as_type.is_some() {
+            return None;
+        }
+
+        let Type::Path(mut path) = self.ty.clone() else {
+            return None;
+        };
+
+        if path.qself.is_some() {
+            return None;
+        }
+
+        let first_ident = path.path.segments.first().map(|s| s.ident.to_string())?;
+        if matches!(first_ident.as_str(), "std" | "core" | "alloc") {
+            return None;
+        }
+
+        let last = path.path.segments.last_mut()?;
+        match last.arguments {
+            PathArguments::None | PathArguments::AngleBracketed(_) => {}
+            _ => return None,
+        }
+
+        let type_name = last.ident.to_string();
+        if !type_name
+            .chars()
+            .next()
+            .map(|ch| ch.is_ascii_uppercase())
+            .unwrap_or(false)
+        {
+            return None;
+        }
+
+        if type_name.starts_with("Partial")
+            || matches!(
+                type_name.as_str(),
+                "String"
+                    | "Self"
+                    | "bool"
+                    | "char"
+                    | "str"
+                    | "i8"
+                    | "i16"
+                    | "i32"
+                    | "i64"
+                    | "i128"
+                    | "isize"
+                    | "u8"
+                    | "u16"
+                    | "u32"
+                    | "u64"
+                    | "u128"
+                    | "usize"
+                    | "f32"
+                    | "f64"
+                    | "Option"
+                    | "Vec"
+                    | "Box"
+                    | "Rc"
+                    | "Arc"
+                    | "Cow"
+                    | "Result"
+                    | "HashMap"
+                    | "BTreeMap"
+                    | "HashSet"
+                    | "BTreeSet"
+            )
+            || (type_name.len() == 1
+                && type_name
+                    .chars()
+                    .next()
+                    .map(|ch| ch.is_ascii_uppercase())
+                    .unwrap_or(false))
+        {
+            return None;
+        }
+
+        let partial_name = format!("Partial{type_name}");
+        last.ident = Ident::new(&partial_name, last.ident.span());
+
+        Some(Type::Path(path))
+    }
+
+    pub fn is_auto_nested(&self) -> bool {
+        self.auto_nested_ty().is_some()
+    }
+
     fn validate(self) -> Result<Self> {
         let mut acc = darling::Error::accumulator();
 
@@ -89,6 +177,8 @@ impl ToTokens for FieldReceiver {
             src_type.to_owned()
         } else if let Some(ty) = &self.as_type {
             ty.to_owned()
+        } else if let Some(nested) = self.auto_nested_ty() {
+            nested
         } else {
             let ty: Type = parse_quote! {
                 Option<#src_type>

--- a/crates/partially_derive/src/internal/impl_partial.rs
+++ b/crates/partially_derive/src/internal/impl_partial.rs
@@ -35,8 +35,11 @@ impl<'a> ToTokens for ImplPartial<'a> {
             parse_quote!(partially)
         };
 
-        let field_is_somes = fields
+        let has_nested_fields = fields.iter().any(|f| f.is_auto_nested());
+
+        let non_nested_field_is_somes: Vec<_> = fields
             .iter()
+            .filter(|f| !f.is_auto_nested())
             .map(|f| {
                 // this is enforced with a better error by [`FieldReceiver::validate`].
                 let from_ident = f.ident.as_ref().unwrap();
@@ -46,7 +49,14 @@ impl<'a> ToTokens for ImplPartial<'a> {
                 quote!(partial.#to_ident.is_some())
             })
             .collect();
-        let field_is_somes = TokenVec::new_with_vec_and_sep(field_is_somes, Separator::Or);
+        let has_non_nested_fields = !non_nested_field_is_somes.is_empty();
+        let non_nested_field_is_somes =
+            TokenVec::new_with_vec_and_sep(non_nested_field_is_somes, Separator::Or);
+        let field_is_somes = if has_nested_fields || !has_non_nested_fields {
+            quote!(false || #non_nested_field_is_somes)
+        } else {
+            quote!(#non_nested_field_is_somes)
+        };
 
         let field_applicators = fields
             .iter()
@@ -56,9 +66,15 @@ impl<'a> ToTokens for ImplPartial<'a> {
 
                 let to_ident = f.rename.as_ref().unwrap_or(from_ident);
 
-                quote! {
-                    if let Some(#to_ident) = partial.#to_ident {
-                        self.#from_ident = #to_ident.into();
+                if f.is_auto_nested() {
+                    quote! {
+                        will_apply_some = #krate::Partial::apply_some(&mut self.#from_ident, partial.#to_ident) || will_apply_some;
+                    }
+                } else {
+                    quote! {
+                        if let Some(#to_ident) = partial.#to_ident {
+                            self.#from_ident = #to_ident.into();
+                        }
                     }
                 }
             })
@@ -66,12 +82,22 @@ impl<'a> ToTokens for ImplPartial<'a> {
         let field_applicators =
             TokenVec::new_with_vec_and_sep(field_applicators, Separator::Newline);
 
+        let will_apply_some_decl = if has_nested_fields {
+            quote! {
+                let mut will_apply_some = #field_is_somes;
+            }
+        } else {
+            quote! {
+                let will_apply_some = #field_is_somes;
+            }
+        };
+
         tokens.extend(quote! {
             impl #imp #krate::Partial for #from_ident #ty #wher {
                 type Item = #to_ident #ty;
 
                 fn apply_some(&mut self, partial: Self::Item) -> bool {
-                    let will_apply_some = #field_is_somes;
+                    #will_apply_some_decl
 
                     #field_applicators
 

--- a/crates/partially_derive/src/internal/impl_partial.rs
+++ b/crates/partially_derive/src/internal/impl_partial.rs
@@ -52,7 +52,9 @@ impl<'a> ToTokens for ImplPartial<'a> {
         let has_non_nested_fields = !non_nested_field_is_somes.is_empty();
         let non_nested_field_is_somes =
             TokenVec::new_with_vec_and_sep(non_nested_field_is_somes, Separator::Or);
-        let field_is_somes = if has_nested_fields || !has_non_nested_fields {
+        let field_is_somes = if !has_non_nested_fields {
+            quote!(false)
+        } else if has_nested_fields {
             quote!(false || #non_nested_field_is_somes)
         } else {
             quote!(#non_nested_field_is_somes)

--- a/crates/partially_derive/src/internal/impl_partial.rs
+++ b/crates/partially_derive/src/internal/impl_partial.rs
@@ -1,5 +1,5 @@
 use quote::{quote, ToTokens};
-use syn::{parse_quote, Generics, Ident, Path};
+use syn::{Generics, Ident, Path};
 
 use super::{
     field_receiver::FieldReceiver,
@@ -7,7 +7,7 @@ use super::{
 };
 
 pub struct ImplPartial<'a> {
-    pub krate: &'a Option<Path>,
+    pub krate: &'a Path,
     pub generics: &'a Generics,
     pub from_ident: &'a Ident,
     pub to_ident: &'a Ident,
@@ -28,18 +28,11 @@ impl<'a> ToTokens for ImplPartial<'a> {
 
         let (imp, ty, wher) = generics.split_for_impl();
 
-        // parse the crate config, or use `partially` for the crate path
-        let krate = if let Some(krate) = krate {
-            krate.to_owned()
-        } else {
-            parse_quote!(partially)
-        };
-
-        let has_nested_fields = fields.iter().any(|f| f.is_auto_nested());
+        let has_nested_fields = fields.iter().any(|f| f.nested.is_present());
 
         let non_nested_field_is_somes: Vec<_> = fields
             .iter()
-            .filter(|f| !f.is_auto_nested())
+            .filter(|f| !f.nested.is_present())
             .map(|f| {
                 // this is enforced with a better error by [`FieldReceiver::validate`].
                 let from_ident = f.ident.as_ref().unwrap();
@@ -68,7 +61,7 @@ impl<'a> ToTokens for ImplPartial<'a> {
 
                 let to_ident = f.rename.as_ref().unwrap_or(from_ident);
 
-                if f.is_auto_nested() {
+                if f.nested.is_present() {
                     quote! {
                         will_apply_some = #krate::Partial::apply_some(&mut self.#from_ident, partial.#to_ident) || will_apply_some;
                     }

--- a/crates/partially_derive/src/internal/mod.rs
+++ b/crates/partially_derive/src/internal/mod.rs
@@ -531,4 +531,62 @@ mod test {
 
         assert_eq!(expanded.to_string(), expected.to_string());
     }
+
+    #[test]
+    fn nested_e2e() {
+        let mut input: DeriveInput = parse_quote! {
+            #[derive(partially::Partial, Default, Debug)]
+            #[partially(derive(Default, Debug))]
+            struct Outer {
+                value: String,
+                inner: Inner,
+            }
+        };
+
+        let expanded = expand_derive_partial(&mut input);
+
+        let expected: TokenStream = parse_quote! {
+            #[derive(Default, Debug)]
+            struct PartialOuter {
+                value: Option<String>,
+                inner: PartialInner
+            }
+
+            impl partially::Partial for Outer {
+                type Item = PartialOuter;
+
+                fn apply_some(&mut self, partial: Self::Item) -> bool {
+                    let mut will_apply_some = false ||
+                        partial.value.is_some();
+
+                    if let Some(value) = partial.value {
+                        self.value = value.into();
+                    }
+
+                    will_apply_some = partially::Partial::apply_some(&mut self.inner, partial.inner) || will_apply_some;
+
+                    will_apply_some
+                }
+            }
+
+            impl partially::Partial for PartialOuter {
+                type Item = PartialOuter;
+
+                fn apply_some(&mut self, partial: Self::Item) -> bool {
+                    let mut will_apply_some = false ||
+                        partial.value.is_some();
+
+                    if let Some(value) = partial.value {
+                        self.value = value.into();
+                    }
+
+                    will_apply_some = partially::Partial::apply_some(&mut self.inner, partial.inner) || will_apply_some;
+
+                    will_apply_some
+                }
+            }
+        };
+
+        assert_eq!(expanded.to_string(), expected.to_string());
+    }
 }

--- a/crates/partially_derive/src/internal/mod.rs
+++ b/crates/partially_derive/src/internal/mod.rs
@@ -539,6 +539,7 @@ mod test {
             #[partially(derive(Default, Debug))]
             struct Outer {
                 value: String,
+                #[partially(nested)]
                 inner: Inner,
             }
         };
@@ -549,7 +550,7 @@ mod test {
             #[derive(Default, Debug)]
             struct PartialOuter {
                 value: Option<String>,
-                inner: PartialInner
+                inner: <Inner as partially::Partial>::Item
             }
 
             impl partially::Partial for Outer {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add an explicit field option: `#[partially(nested)]`
- for `nested` fields, generate `<FieldType as Partial>::Item` in the partial struct
- for `nested` fields, generated `apply_some` recurses via `Partial::apply_some`
- keep nested behavior opt-in (no heuristic auto-detection)
- preserve precedence/validation with other field options (`omit`, `transparent`, `as_type`)
- add tests/docs/changelog updates for explicit nested behavior
- add regression coverage that non-annotated fields stay `Option<T>` and reject nested payloads at compile time

## Testing
- `cargo test -p partially_derive`
- `cargo test -p partially`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d917d7df-3026-4afa-81a3-9a6c318e3189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d917d7df-3026-4afa-81a3-9a6c318e3189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

