### PR TITLE
feat(derive): add `nested` attribute for hierarchical Partial structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,3 +169,9 @@ Instructs the macro to skip wrapping the generated field in `Option<T>`, instead
 Instructs the macro to use the provided type instead of `Option<T>` when generating the field. Note that the provided type will be used verbatim, so if you expect an `Option<T>` value, you'll need to manually specify that.
 
 Note: When using `as_type`, the given type must `Into<BaseType>` where `BaseType` is the original field type. This is required for `Partial` trait implementation.
+
+#### nested
+
+> Usage example: `#[partially(nested)]`
+
+Indicates to the macro that this field implements `Partial`. The type in the generated struct will be the associated `Partial::Item` type, and the struct's `Partial::apply_some` implementation will delegate to `Partial::apply_some` on the field.

--- a/crates/partially/src/lib.rs
+++ b/crates/partially/src/lib.rs
@@ -39,6 +39,9 @@
 /// > Usage example: `#[partially(as_type = "Option<f32>")]`.
 /// Instructs the macro to use the provided type instead of [`Option<T>`] when generating the field. Note that the provided type will be used verbatim, so if you expect an [`Option<T>`] value, you'll need to manually specify that.
 /// Note: When using `as_type`, the given type must `Into<BaseType>` where `BaseType` is the original field type. This is required for `Partial` trait implementation.
+/// ### nested
+/// > Usage example: `#[partially(nested)]`
+/// Indicates to the macro that this field implements [`Partial`]. The type in the generated struct will be the associated [`Partial::Item`] type, and the struct's [`Partial::apply_some`] implementation will delegate to [`Partial::apply_some`] on the field.
 ///
 /// ## Example
 /// ```

--- a/crates/partially/tests/derive/mod.rs
+++ b/crates/partially/tests/derive/mod.rs
@@ -1,4 +1,5 @@
 mod basic;
 mod container_attrs;
 mod generic;
+mod nested;
 mod retyped;

--- a/crates/partially/tests/derive/nested.rs
+++ b/crates/partially/tests/derive/nested.rs
@@ -1,0 +1,115 @@
+use partially::Partial;
+
+#[derive(Debug, partially_derive::Partial)]
+#[partially(derive(Default))]
+struct Inner {
+    v: String,
+}
+
+#[derive(Debug, partially_derive::Partial)]
+#[partially(derive(Default))]
+struct Outer {
+    v: String,
+    #[partially(nested)]
+    inner: Inner,
+}
+
+#[test]
+fn nested_apply_some() {
+    let mut data = Outer {
+        v: "v1".to_string(),
+        inner: Inner {
+            v: "v2".to_string(),
+        },
+    };
+
+    let empty_partial = PartialOuter::default();
+    let full_partial = PartialOuter {
+        v: Some("v3".to_string()),
+        inner: PartialInner {
+            v: Some("v4".to_string()),
+        },
+    };
+
+    assert!(!data.apply_some(empty_partial));
+    assert_eq!(data.v, "v1");
+    assert_eq!(data.inner.v, "v2");
+
+    assert!(data.apply_some(full_partial));
+    assert_eq!(data.v, "v3");
+    assert_eq!(data.inner.v, "v4");
+}
+
+#[test]
+fn nested_partial_to_partial() {
+    let mut partial = PartialOuter::default();
+    let update = PartialOuter {
+        v: Some("updated".to_string()),
+        inner: PartialInner {
+            v: Some("nested_updated".to_string()),
+        },
+    };
+
+    assert!(partial.apply_some(update));
+    assert_eq!(partial.v, Some("updated".to_string()));
+    assert_eq!(partial.inner.v, Some("nested_updated".to_string()));
+}
+
+#[test]
+fn nested_only_inner_changes() {
+    let mut data = Outer {
+        v: "original".to_string(),
+        inner: Inner {
+            v: "original_inner".to_string(),
+        },
+    };
+
+    let partial = PartialOuter {
+        v: None,
+        inner: PartialInner {
+            v: Some("changed".to_string()),
+        },
+    };
+
+    assert!(data.apply_some(partial));
+    assert_eq!(data.v, "original");
+    assert_eq!(data.inner.v, "changed");
+}
+
+#[derive(Debug, partially_derive::Partial)]
+#[partially(derive(Default))]
+struct Mixed {
+    normal: String,
+    #[partially(nested)]
+    child: Inner,
+    #[partially(transparent)]
+    transparent_field: Option<String>,
+    #[partially(omit)]
+    _omitted: String,
+}
+
+#[test]
+fn nested_with_other_field_options() {
+    let mut data = Mixed {
+        normal: "a".to_string(),
+        child: Inner {
+            v: "b".to_string(),
+        },
+        transparent_field: Some("c".to_string()),
+        _omitted: "d".to_string(),
+    };
+
+    let partial = PartialMixed {
+        normal: Some("x".to_string()),
+        child: PartialInner {
+            v: Some("y".to_string()),
+        },
+        transparent_field: Some("z".to_string()),
+    };
+
+    assert!(data.apply_some(partial));
+    assert_eq!(data.normal, "x");
+    assert_eq!(data.child.v, "y");
+    assert_eq!(data.transparent_field, Some("z".to_string()));
+    assert_eq!(data._omitted, "d");
+}

--- a/crates/partially_derive/src/internal/derive_receiver.rs
+++ b/crates/partially_derive/src/internal/derive_receiver.rs
@@ -5,10 +5,10 @@ use darling::{
 };
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
-use syn::{Attribute, Generics, Ident, Path, Visibility};
+use syn::{parse_quote, Attribute, Generics, Ident, Path, Visibility};
 
 use super::{
-    field_receiver::FieldReceiver,
+    field_receiver::{FieldReceiver, FieldTokenizer},
     impl_partial::ImplPartial,
     meta_attribute::MetaAttribute,
     token_vec::{Separator, TokenVec},
@@ -89,6 +89,12 @@ impl ToTokens for DeriveReceiver {
             ref krate,
         } = *self;
 
+        let krate: Path = if let Some(krate) = krate {
+            krate.to_owned()
+        } else {
+            parse_quote!(partially)
+        };
+
         let (_, ty, wher) = generics.split_for_impl();
 
         let fields: Vec<_> = data
@@ -132,7 +138,12 @@ impl ToTokens for DeriveReceiver {
             #additional_attrs
         });
 
-        let field_tokens = TokenVec::new_with_vec_and_sep(fields.clone(), Separator::CommaNewline);
+        let field_tokenizers: Vec<_> = fields
+            .iter()
+            .map(|field| FieldTokenizer { field, krate: &krate })
+            .collect();
+        let field_tokens =
+            TokenVec::new_with_vec_and_sep(field_tokenizers, Separator::CommaNewline);
 
         // write the struct
         tokens.extend(quote! {
@@ -143,7 +154,7 @@ impl ToTokens for DeriveReceiver {
 
         // create the impl
         let impl_partial = ImplPartial {
-            krate,
+            krate: &krate,
             from_ident: ident,
             to_ident: &to_ident,
             generics,
@@ -157,7 +168,7 @@ impl ToTokens for DeriveReceiver {
 
         // create the partial => partial impl
         let partial_impl_partial = ImplPartial {
-            krate,
+            krate: &krate,
             from_ident: &to_ident,
             to_ident: &to_ident,
             generics,

--- a/crates/partially_derive/src/internal/field_receiver.rs
+++ b/crates/partially_derive/src/internal/field_receiver.rs
@@ -1,6 +1,6 @@
 use darling::{util::Flag, FromField, Result};
 use quote::{quote, ToTokens};
-use syn::{parse_quote, Ident, Type, Visibility};
+use syn::{parse_quote, Ident, Path, Type, Visibility};
 
 #[derive(Debug, FromField)]
 #[darling(attributes(partially), forward_attrs, and_then = FieldReceiver::validate)]
@@ -39,6 +39,11 @@ pub struct FieldReceiver {
     /// Note: If specified, the given [`Type`] will be used verbatim, not wrapped in an [`Option`].
     /// Note: By default, [`Option<Self::ty>`] is used.
     pub as_type: Option<Type>,
+
+    /// A flag indicating that this field has a type that implements [`Partial`] and should
+    /// use its associated `Partial::Item` type in the generated struct, with `apply_some`
+    /// delegated to the nested field.
+    pub nested: Flag,
 }
 
 impl FieldReceiver {
@@ -52,16 +57,28 @@ impl FieldReceiver {
         }
 
         if self.omit.is_present()
-            && (self.rename.is_some() || self.transparent.is_present() || self.as_type.is_some())
+            && (self.rename.is_some()
+                || self.transparent.is_present()
+                || self.as_type.is_some()
+                || self.nested.is_present())
         {
             acc.push(darling::Error::custom(
                 "cannot use omit with any other options",
             ));
         }
 
-        if self.transparent.is_present() && self.as_type.is_some() {
+        let exclusive_count = [
+            self.transparent.is_present(),
+            self.as_type.is_some(),
+            self.nested.is_present(),
+        ]
+        .iter()
+        .filter(|&&b| b)
+        .count();
+
+        if exclusive_count > 1 {
             acc.push(darling::Error::custom(
-                "cannot use both transparent and as_type",
+                "transparent, as_type and nested are mutually exclusive",
             ));
         }
 
@@ -69,26 +86,40 @@ impl FieldReceiver {
     }
 }
 
-impl ToTokens for FieldReceiver {
+/// Wrapper that pairs a [`FieldReceiver`] with a crate [`Path`] so that nested fields
+/// can reference `<T as krate::Partial>::Item`. Implements [`ToTokens`] for use with
+/// [`TokenVec`].
+pub struct FieldTokenizer<'a> {
+    pub field: &'a FieldReceiver,
+    pub krate: &'a Path,
+}
+
+impl ToTokens for FieldTokenizer<'_> {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        if self.omit.is_present() {
+        let f = self.field;
+        let krate = self.krate;
+
+        if f.omit.is_present() {
             return;
         }
 
-        // this is enforced with a better error by [`FieldReceiver::validate`].
-        let src_name = self.ident.as_ref().expect("expected a named field");
+        let src_name = f.ident.as_ref().expect("expected a named field");
 
-        let dst_name = if let Some(name) = &self.rename {
+        let dst_name = if let Some(name) = &f.rename {
             name
         } else {
             src_name
         };
 
-        let src_type = &self.ty;
-        let dst_type = if self.transparent.is_present() {
+        let src_type = &f.ty;
+        let dst_type = if f.transparent.is_present() {
             src_type.to_owned()
-        } else if let Some(ty) = &self.as_type {
+        } else if let Some(ty) = &f.as_type {
             ty.to_owned()
+        } else if f.nested.is_present() {
+            parse_quote! {
+                <#src_type as #krate::Partial>::Item
+            }
         } else {
             let ty: Type = parse_quote! {
                 Option<#src_type>
@@ -97,8 +128,8 @@ impl ToTokens for FieldReceiver {
             ty
         };
 
-        let vis = &self.vis;
-        let forwarded_attrs = &self.attrs;
+        let vis = &f.vis;
+        let forwarded_attrs = &f.attrs;
 
         for attr in forwarded_attrs {
             tokens.extend(quote! {
@@ -131,6 +162,7 @@ mod test {
             omit: Flag::default(),
             transparent: Flag::default(),
             as_type: None,
+            nested: Flag::default(),
         }
     }
 
@@ -172,10 +204,47 @@ mod test {
     }
 
     #[test]
+    fn invalidate_omit_nested() {
+        let mut instance = make_dummy();
+        instance.omit = Flag::present();
+        instance.nested = Flag::present();
+
+        assert!(instance.validate().is_err())
+    }
+
+    #[test]
     fn invalidate_transparent_as_type() {
         let mut instance = make_dummy();
         instance.transparent = Flag::present();
         instance.as_type = Some(syn::Type::Verbatim(quote!(NewDummyField)));
+
+        assert!(instance.validate().is_err())
+    }
+
+    #[test]
+    fn invalidate_transparent_nested() {
+        let mut instance = make_dummy();
+        instance.transparent = Flag::present();
+        instance.nested = Flag::present();
+
+        assert!(instance.validate().is_err())
+    }
+
+    #[test]
+    fn invalidate_as_type_nested() {
+        let mut instance = make_dummy();
+        instance.as_type = Some(syn::Type::Verbatim(quote!(NewDummyField)));
+        instance.nested = Flag::present();
+
+        assert!(instance.validate().is_err())
+    }
+
+    #[test]
+    fn invalidate_transparent_as_type_nested() {
+        let mut instance = make_dummy();
+        instance.transparent = Flag::present();
+        instance.as_type = Some(syn::Type::Verbatim(quote!(NewDummyField)));
+        instance.nested = Flag::present();
 
         assert!(instance.validate().is_err())
     }

--- a/crates/partially_derive/src/internal/impl_partial.rs
+++ b/crates/partially_derive/src/internal/impl_partial.rs
@@ -1,5 +1,5 @@
 use quote::{quote, ToTokens};
-use syn::{parse_quote, Generics, Ident, Path};
+use syn::{Generics, Ident, Path};
 
 use super::{
     field_receiver::FieldReceiver,
@@ -7,7 +7,7 @@ use super::{
 };
 
 pub struct ImplPartial<'a> {
-    pub krate: &'a Option<Path>,
+    pub krate: &'a Path,
     pub generics: &'a Generics,
     pub from_ident: &'a Ident,
     pub to_ident: &'a Ident,
@@ -28,37 +28,50 @@ impl<'a> ToTokens for ImplPartial<'a> {
 
         let (imp, ty, wher) = generics.split_for_impl();
 
-        // parse the crate config, or use `partially` for the crate path
-        let krate = if let Some(krate) = krate {
-            krate.to_owned()
-        } else {
-            parse_quote!(partially)
-        };
+        let has_nested = fields.iter().any(|f| f.nested.is_present());
 
-        let field_is_somes = fields
+        let non_nested_is_somes: Vec<_> = fields
             .iter()
+            .filter(|f| !f.nested.is_present())
             .map(|f| {
-                // this is enforced with a better error by [`FieldReceiver::validate`].
                 let from_ident = f.ident.as_ref().unwrap();
-
                 let to_ident = f.rename.as_ref().unwrap_or(from_ident);
-
                 quote!(partial.#to_ident.is_some())
             })
             .collect();
-        let field_is_somes = TokenVec::new_with_vec_and_sep(field_is_somes, Separator::Or);
 
-        let field_applicators = fields
+        let will_apply_some_binding = if has_nested {
+            if non_nested_is_somes.is_empty() {
+                quote!(let mut will_apply_some = false;)
+            } else {
+                let is_somes =
+                    TokenVec::new_with_vec_and_sep(non_nested_is_somes, Separator::Or);
+                quote!(let mut will_apply_some = #is_somes;)
+            }
+        } else {
+            let is_somes =
+                TokenVec::new_with_vec_and_sep(non_nested_is_somes, Separator::Or);
+            quote!(let will_apply_some = #is_somes;)
+        };
+
+        let field_applicators: Vec<_> = fields
             .iter()
             .map(|f| {
-                // this is enforced with a better error by [`FieldReceiver::validate`].
                 let from_ident = f.ident.as_ref().unwrap();
-
                 let to_ident = f.rename.as_ref().unwrap_or(from_ident);
 
-                quote! {
-                    if let Some(#to_ident) = partial.#to_ident {
-                        self.#from_ident = #to_ident.into();
+                if f.nested.is_present() {
+                    quote! {
+                        will_apply_some = #krate::Partial::apply_some(
+                            &mut self.#from_ident,
+                            partial.#to_ident
+                        ) || will_apply_some;
+                    }
+                } else {
+                    quote! {
+                        if let Some(#to_ident) = partial.#to_ident {
+                            self.#from_ident = #to_ident.into();
+                        }
                     }
                 }
             })
@@ -71,7 +84,7 @@ impl<'a> ToTokens for ImplPartial<'a> {
                 type Item = #to_ident #ty;
 
                 fn apply_some(&mut self, partial: Self::Item) -> bool {
-                    let will_apply_some = #field_is_somes;
+                    #will_apply_some_binding
 
                     #field_applicators
 

--- a/crates/partially_derive/src/internal/mod.rs
+++ b/crates/partially_derive/src/internal/mod.rs
@@ -430,6 +430,122 @@ mod test {
     }
 
     #[test]
+    fn nested_e2e() {
+        let mut input: DeriveInput = parse_quote! {
+            #[derive(partially::Partial, Default, Debug)]
+            #[partially(derive(Default, Debug))]
+            struct Data {
+                normal_field: String,
+                #[partially(nested)]
+                child_field: Inner
+            }
+        };
+
+        let expanded = expand_derive_partial(&mut input);
+
+        let expected: TokenStream = parse_quote! {
+            #[derive(Default, Debug)]
+            struct PartialData {
+                normal_field: Option<String>,
+                child_field: <Inner as partially::Partial>::Item
+            }
+
+            impl partially::Partial for Data {
+                type Item = PartialData;
+
+                fn apply_some(&mut self, partial: Self::Item) -> bool {
+                    let mut will_apply_some = partial.normal_field.is_some();
+
+                    if let Some(normal_field) = partial.normal_field {
+                        self.normal_field = normal_field.into();
+                    }
+
+                    will_apply_some = partially::Partial::apply_some(
+                        &mut self.child_field,
+                        partial.child_field
+                    ) || will_apply_some;
+
+                    will_apply_some
+                }
+            }
+
+            impl partially::Partial for PartialData {
+                type Item = PartialData;
+
+                fn apply_some(&mut self, partial: Self::Item) -> bool {
+                    let mut will_apply_some = partial.normal_field.is_some();
+
+                    if let Some(normal_field) = partial.normal_field {
+                        self.normal_field = normal_field.into();
+                    }
+
+                    will_apply_some = partially::Partial::apply_some(
+                        &mut self.child_field,
+                        partial.child_field
+                    ) || will_apply_some;
+
+                    will_apply_some
+                }
+            }
+        };
+
+        assert_eq!(expanded.to_string(), expected.to_string());
+    }
+
+    #[test]
+    fn nested_only_e2e() {
+        let mut input: DeriveInput = parse_quote! {
+            #[derive(partially::Partial)]
+            #[partially(derive(Default))]
+            struct Wrapper {
+                #[partially(nested)]
+                inner: Inner
+            }
+        };
+
+        let expanded = expand_derive_partial(&mut input);
+
+        let expected: TokenStream = parse_quote! {
+            #[derive(Default)]
+            struct PartialWrapper {
+                inner: <Inner as partially::Partial>::Item
+            }
+
+            impl partially::Partial for Wrapper {
+                type Item = PartialWrapper;
+
+                fn apply_some(&mut self, partial: Self::Item) -> bool {
+                    let mut will_apply_some = false;
+
+                    will_apply_some = partially::Partial::apply_some(
+                        &mut self.inner,
+                        partial.inner
+                    ) || will_apply_some;
+
+                    will_apply_some
+                }
+            }
+
+            impl partially::Partial for PartialWrapper {
+                type Item = PartialWrapper;
+
+                fn apply_some(&mut self, partial: Self::Item) -> bool {
+                    let mut will_apply_some = false;
+
+                    will_apply_some = partially::Partial::apply_some(
+                        &mut self.inner,
+                        partial.inner
+                    ) || will_apply_some;
+
+                    will_apply_some
+                }
+            }
+        };
+
+        assert_eq!(expanded.to_string(), expected.to_string());
+    }
+
+    #[test]
     fn extensive_attr_e2e() {
         let mut input: DeriveInput = parse_quote! {
             #[derive(partially::Partial, Default, Debug)]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the `nested` field attribute from PR #19, addressing all review feedback. When a field's type implements `Partial`, marking it with `#[partially(nested)]` will:

- Use `<T as Partial>::Item` as the field type in the generated struct (instead of `Option<T>`)
- Delegate to `Partial::apply_some` on the nested field in the `apply_some` implementation

### Example

```rust
#[derive(Partial)]
#[partially(derive(Default))]
struct Inner {
    v: String,
}

#[derive(Partial)]
#[partially(derive(Default))]
struct Outer {
    v: String,
    #[partially(nested)]
    inner: Inner,
}
```

Generates:

```rust
struct PartialOuter {
    v: Option<String>,
    inner: <Inner as partially::Partial>::Item, // = PartialInner
}
```

## Review issues addressed from PR #19

| Issue | Resolution |
|-------|------------|
| Generated code regresses for all users (`mut`, `false \|\|`) | `mut` and `false` seed are only emitted when at least one nested field exists. Existing tests are unchanged. |
| `FieldReceiver` no longer implements `ToTokens` trait | Introduced `FieldTokenizer` wrapper that carries the crate path and implements `ToTokens`, keeping `TokenVec`-based struct generation declarative. |
| No e2e token-level snapshot test for `nested` | Added `nested_e2e` (mixed fields) and `nested_only_e2e` (nested-only struct) snapshot tests in `mod.rs`. |
| `as i32` boolean arithmetic style | Replaced with idiomatic `[bool].iter().filter().count()` for mutual exclusivity validation. |
| README missing trailing newline | Fixed. |
| Test naming and coverage gaps | Used `Inner`/`Outer` naming; added partial-to-partial, nested-only-inner-changes, and composition-with-other-options integration tests. |

## Changes

- `crates/partially_derive/src/internal/field_receiver.rs` — Added `nested` flag, `FieldTokenizer` wrapper, idiomatic validation
- `crates/partially_derive/src/internal/impl_partial.rs` — Conditional `mut`/`false` emission, nested `apply_some` delegation
- `crates/partially_derive/src/internal/derive_receiver.rs` — Resolve `krate` once, use `FieldTokenizer` for struct fields
- `crates/partially_derive/src/internal/mod.rs` — Two new e2e snapshot tests
- `crates/partially/tests/derive/nested.rs` — Four integration tests
- `crates/partially/src/lib.rs` — Doc updates
- `README.md` — Documentation for `nested` attribute
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4462948-cc8c-4abe-bd9e-1f6134472e81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4462948-cc8c-4abe-bd9e-1f6134472e81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

