### PR TITLE
Implement From<Struct> for PartialStruct

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -20,18 +20,17 @@ jobs:
       - name: Install cargo-all-features
         run: cargo install cargo-all-features
       - name: Build
-        run: cargo build-all-features --exclude test_no_std --workspace --verbose
+        run: cargo build-all-features
       - name: Run tests
-        run: cargo test-all-features --exclude test_no_std --workspace --verbose
+        run: cargo test-all-features
       - name: Run clippy
-        run: cargo clippy --exclude test_no_std --workspace --verbose
+        run: cargo clippy --workspace --verbose
 
   build_no_std:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
-      # the test_no_std crate requires the nightly toolchain
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
       - name: Build test_no_std
-        run: cd crates/test_no_std && cargo +nightly build --verbose
+        run: cargo build -p test_no_std --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,9 @@
 [workspace]
 resolver = "2"
 members = ["crates/*"]
+
+# The test_no_std crate requires this:
+# > unwinding panics are not supported without std
+# Notably, this profile doesn't affect downstream users of the crate.
+[profile.dev]
+panic = "abort"

--- a/crates/partially/src/lib.rs
+++ b/crates/partially/src/lib.rs
@@ -24,6 +24,9 @@
 /// ### crate
 /// > Usage example: `#[partially(crate = "my_partially_crate")]`.
 /// Instructs the macro to use a different base path for the `Partial` trait implementation. By default, `partially` is used. This can be useful if you've forked the `partially` crate.
+/// ### skip_from_full
+/// > Usage example: `#[partially(skip_from_full)]`.
+/// By default, the macro generates `impl From<YourStruct> for PartialYourStruct`, mapping each base field into the partial: normal optional fields use `Some(value)` (with `.into()` for `as_type` fields), and `transparent` fields are copied as-is. Set this flag to skip generating that implementation. For `as_type` fields, the base field type must implement `Into` the partial field's inner type when this impl is generated.
 ///
 /// ## Field Options
 /// ### rename

--- a/crates/partially/tests/derive/basic.rs
+++ b/crates/partially/tests/derive/basic.rs
@@ -8,6 +8,33 @@ struct Data {
 }
 
 #[test]
+fn from_full_maps_all_some() {
+    let full = Data {
+        a: "a".to_string(),
+        b: "b".to_string(),
+    };
+    let partial: PartialData = full.into();
+    assert_eq!(partial.a, Some("a".to_string()));
+    assert_eq!(partial.b, Some("b".to_string()));
+}
+
+#[test]
+fn skip_from_full() {
+    #[derive(Partial)]
+    #[partially(skip_from_full)]
+    #[allow(unused)]
+    struct Struct {
+        a: String,
+    }
+    // NB: Without `skip_from_full` this would complain about a duplicate impl
+    impl From<Struct> for PartialStruct {
+        fn from(_: Struct) -> Self {
+            unimplemented!()
+        }
+    }
+}
+
+#[test]
 fn basic_apply_some() {
     let empty_partial = PartialData::default();
     let full_partial = PartialData {

--- a/crates/partially/tests/derive/retyped.rs
+++ b/crates/partially/tests/derive/retyped.rs
@@ -26,6 +26,7 @@ impl From<V1> for V2 {
 }
 
 #[derive(partially_derive::Partial)]
+#[partially(skip_from_full)]
 #[partially(derive(Default))]
 struct Data {
     #[partially(as_type = "Option<V1>")]

--- a/crates/partially_derive/CHANGELOG.md
+++ b/crates/partially_derive/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- *(derive)* implements `From<Struct>` for `PartialStruct`
+
 ## [0.2.1](https://github.com/bengreenier/partially/compare/partially_derive-v0.2.0...partially_derive-v0.2.1) - 2024-01-20
 
 ### Added

--- a/crates/partially_derive/src/internal/derive_receiver.rs
+++ b/crates/partially_derive/src/internal/derive_receiver.rs
@@ -9,6 +9,7 @@ use syn::{Attribute, Generics, Ident, Path, Visibility};
 
 use super::{
     field_receiver::FieldReceiver,
+    impl_from_full::ImplFromFull,
     impl_partial::ImplPartial,
     meta_attribute::MetaAttribute,
     token_vec::{Separator, TokenVec},
@@ -72,6 +73,13 @@ pub struct DeriveReceiver {
     /// Receives an optional [`Path`] defining the path to the `partially` crate.
     #[darling(rename = "crate")]
     pub krate: Option<Path>,
+
+    /// When set, skips generating `impl core::convert::From<FullStruct> for PartialStruct`.
+    ///
+    /// For `#[partially(as_type = "...")]` fields, the base field type must implement
+    /// `Into` the partial field's inner type (the inverse direction of what `apply_some` uses).
+    #[darling(rename = "skip_from_full")]
+    pub skip_from_full: Flag,
 }
 
 impl ToTokens for DeriveReceiver {
@@ -87,6 +95,7 @@ impl ToTokens for DeriveReceiver {
             ref additional_attrs,
             ref skip_attrs,
             ref krate,
+            ref skip_from_full,
         } = *self;
 
         let (_, ty, wher) = generics.split_for_impl();
@@ -140,6 +149,18 @@ impl ToTokens for DeriveReceiver {
                 #field_tokens
             }
         });
+
+        if !skip_from_full.is_present() {
+            let impl_from_full = ImplFromFull {
+                generics,
+                full_ident: ident,
+                partial_ident: &to_ident,
+                fields: &fields,
+            };
+            tokens.extend(quote! {
+                #impl_from_full
+            });
+        }
 
         // create the impl
         let impl_partial = ImplPartial {

--- a/crates/partially_derive/src/internal/impl_from_full.rs
+++ b/crates/partially_derive/src/internal/impl_from_full.rs
@@ -1,0 +1,56 @@
+use quote::{quote, ToTokens};
+use syn::{Generics, Ident};
+
+use super::{
+    field_receiver::FieldReceiver,
+    token_vec::{Separator, TokenVec},
+};
+
+pub struct ImplFromFull<'a> {
+    pub generics: &'a Generics,
+    pub full_ident: &'a Ident,
+    pub partial_ident: &'a Ident,
+    pub fields: &'a Vec<&'a FieldReceiver>,
+}
+
+impl<'a> ToTokens for ImplFromFull<'a> {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let Self {
+            generics,
+            full_ident,
+            partial_ident,
+            fields,
+        } = self;
+
+        let (imp, ty, wher) = generics.split_for_impl();
+
+        let field_inits = fields
+            .iter()
+            .map(|f| {
+                let from_ident = f.ident.as_ref().unwrap();
+                let to_ident = f.rename.as_ref().unwrap_or(from_ident);
+
+                if f.transparent.is_present() {
+                    quote! {
+                        #to_ident: full.#from_ident
+                    }
+                } else {
+                    quote! {
+                        #to_ident: Some(full.#from_ident.into())
+                    }
+                }
+            })
+            .collect::<Vec<_>>();
+        let field_inits = TokenVec::new_with_vec_and_sep(field_inits, Separator::CommaNewline);
+
+        tokens.extend(quote! {
+            impl #imp core::convert::From<#full_ident #ty> for #partial_ident #ty #wher {
+                fn from(full: #full_ident #ty) -> Self {
+                    Self {
+                        #field_inits
+                    }
+                }
+            }
+        });
+    }
+}

--- a/crates/partially_derive/src/internal/mod.rs
+++ b/crates/partially_derive/src/internal/mod.rs
@@ -7,6 +7,7 @@ use self::derive_receiver::DeriveReceiver;
 
 mod derive_receiver;
 mod field_receiver;
+mod impl_from_full;
 mod impl_partial;
 mod meta_attribute;
 mod token_vec;
@@ -64,6 +65,17 @@ mod test {
                 number_field: Option<f32>,
                 transparent_field: Option<String>,
                 new_field: Option<String>
+            }
+
+            impl core::convert::From<Data> for PartialData {
+                fn from(full: Data) -> Self {
+                    Self {
+                        str_field: Some(full.str_field.into()),
+                        number_field: Some(full.number_field.into()),
+                        transparent_field: full.transparent_field,
+                        new_field: Some(full.old_field.into())
+                    }
+                }
             }
 
             impl partially::Partial for Data {
@@ -134,6 +146,7 @@ mod test {
             #[derive(partially::Partial, Default, Debug)]
             #[partially(rename = "OptData")]
             #[partially(derive(Default, Debug))]
+            #[partially(skip_from_full)]
             #[some_attr]
             struct Data {
                 /// A documented field.
@@ -234,6 +247,7 @@ mod test {
             #[derive(partially::Partial, Default, Debug)]
             #[partially(rename = "PartialData")]
             #[partially(derive(Default, Debug))]
+            #[partially(skip_from_full)]
             #[some_attr]
             struct Data<T> {
                 /// A documented field.
@@ -335,6 +349,7 @@ mod test {
             #[partially(rename = "PartialData")]
             #[partially(derive(Default, Debug))]
             #[partially(crate = "custom_partially")]
+            #[partially(skip_from_full)]
             #[some_attr]
             struct Data<T> where T: Sized {
                 /// A documented field.
@@ -437,6 +452,7 @@ mod test {
             #[partially(attribute(serde(default)))]
             #[partially(attribute(serde(rename = "PascalCase")))]
             #[partially(skip_attributes)]
+            #[partially(skip_from_full)]
             #[some_attr]
             struct Data {
                 /// A documented field.

--- a/crates/test_no_std/src/main.rs
+++ b/crates/test_no_std/src/main.rs
@@ -1,17 +1,16 @@
-#![allow(internal_features)]
-#![feature(lang_items, start)]
-#![no_std]
+#![cfg_attr(not(test), no_std)]
+#![cfg_attr(not(test), no_main)]
 
-#[lang = "eh_personality"]
-#[no_mangle]
-pub extern "C" fn rust_eh_personality() {}
-
+#[cfg(not(test))]
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo) -> ! {
-    unsafe {
-        libc::abort();
-    }
+    unsafe { libc::abort() }
 }
+
+// Prebuilt `core` still references this symbol when linking a `no_std` binary.
+#[cfg(not(test))]
+#[no_mangle]
+pub extern "C" fn rust_eh_personality() {}
 
 //////////////////////////////////////////////////////////////////////////////
 
@@ -22,8 +21,7 @@ struct Test {
     data: i32,
 }
 
-#[start]
-fn start(_argc: isize, _argv: *const *const u8) -> isize {
+fn run_checks() {
     let mut base = Test { data: 1 };
     let partial = PartialTest { data: Some(2) };
 
@@ -33,6 +31,22 @@ fn start(_argc: isize, _argv: *const *const u8) -> isize {
     let partial = PartialTest { data: Some(2) };
 
     assert!(base.apply_some(partial));
+}
 
+// Hosted `no_std`: libc's `crt` already provides `_start`; we only export `main`.
+#[cfg(not(test))]
+#[no_mangle]
+pub extern "C" fn main() -> i32 {
+    run_checks();
     0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::run_checks;
+
+    #[test]
+    fn derives_and_applies_in_test_mode() {
+        run_checks();
+    }
 }


### PR DESCRIPTION
Hi,

this automatically derives `From<Struct>` for `PartialStruct` with an opt-out option. Notably this is a backwards-incompatible change since users of the crate might already be implementing the trait manually. Still, I think this is a sensible default..
I've also included changes to the CI to fix the no_std test and a CLI argument change in cargo-all-features.

Fixes #18